### PR TITLE
exports is now ie11 compatible

### DIFF
--- a/index.js
+++ b/index.js
@@ -340,4 +340,4 @@ var ScrollMagicPluginGsap = function(ScrollMagic, TweenMax, Timeline) {
     });
 };
 
-module.exports = { ScrollMagicPluginGsap };
+module.exports = { ScrollMagicPluginGsap : ScrollMagicPluginGsap };


### PR DESCRIPTION
if you use this plugin it breaks on ie11, because of the module.exports syntax. This PR is a fix for this